### PR TITLE
Forward media of a message

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -8,13 +8,20 @@ from bot.helper.utils import get_formatted_chat
 
 def copy_with_media(client, message, chat, caption):
   if message.media and (message.audio or message.photo or message.document or message.video or message.voice):
-    file = message.download('/tmp/tgfiles/')
     if caption is None:
       caption = message.caption
     if caption is None:
-      client.send_document(chat_id=chat, document=file)
-    else: 
+      caption = ''
+
+    file = message.download('/tmp/tgfiles/')
+    
+    if message.photo:
+      client.send_photo(chat_id=chat, photo=file, caption=caption)
+    else:
       client.send_document(chat_id=chat, document=file, caption=caption)
+      
+    os.remove(file)
+
   else:
     message.copy(chat)
 


### PR DESCRIPTION
New Telegram privacy option in channels doesn't allow to resend media. You need to download the media and upload them to telegram back, so you will be able to forward message with media from channel with protected content. 